### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <spring-kafka.version>2.9.11</spring-kafka.version>
         <kafka.version>3.1.0</kafka.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <ssl-kickstart.version>8.3.4</ssl-kickstart.version>
+        <ayza.version>10.0.0</ayza.version>
         <spring-context.version>5.3.27</spring-context.version>
         <metrics.version>4.0.6</metrics.version>
     </properties>
@@ -402,14 +402,14 @@
 
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart</artifactId>
-            <version>${ssl-kickstart.version}</version>
+            <artifactId>ayza</artifactId>
+            <version>${ayza.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
-            <version>${ssl-kickstart.version}</version>
+            <artifactId>ayza-for-pem</artifactId>
+            <version>${ayza.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience